### PR TITLE
Add Slack Profile CLI to portfolio

### DIFF
--- a/src/lib/defs.ts
+++ b/src/lib/defs.ts
@@ -223,6 +223,15 @@ export const projects: ProjectItem[] = [
     image: "https://cv.jaspermayone.com/jaspermayone-cv.jpeg",
   },
   {
+    title: "Slack Profile CLI",
+    description:
+      "Command-line tool for updating Slack user profiles programmatically. Published to npm and RubyGems with Homebrew support.",
+    link: "https://www.npmjs.com/package/@jaspermayone/slack-profile-cli",
+    github: "jaspermayone/slack-profile-cli",
+    tags: ["Node.js", "Ruby", "CLI", "Slack API"],
+    date: "2025",
+  },
+  {
     title: "MLH Discord Integration",
     description:
       "Discord bot that integrates with MyMLH identity platform for tighter linking of roles and user experience enhancement.",


### PR DESCRIPTION
This PR adds the Slack Profile CLI project to the portfolio page.

## Changes
- Added Slack Profile CLI to the projects list in `src/lib/defs.ts`
- Positioned it as a featured project showcasing:
  - Published to both npm and RubyGems
  - Homebrew support
  - Command-line tool for Slack administration

## Project Details
- **GitHub**: https://github.com/jaspermayone/slack-profile-cli
- **npm**: https://www.npmjs.com/package/@jaspermayone/slack-profile-cli
- **Tags**: Node.js, Ruby, CLI, Slack API